### PR TITLE
add error message for title validation for new events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -19,8 +19,11 @@ class EventsController < ApplicationController
   def create
     @event = Event.new(event_params)
 
-    @event.save
-    redirect_to @event
+   if @event.save
+      redirect_to @event
+    else
+      render 'new'
+    end
   end
 
   def edit

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,5 +1,19 @@
 <%= form_with model: @event, local: true do |form| %>
 
+ <% if @event.errors.any? %>
+    <div id="error_explanation">
+      <h3>
+        Sorry, <%= pluralize(@event.errors.count, "error") %> prohibited
+        this event from being saved:
+      </h3>
+      <ul>
+        <% @event.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+        <h3>Please try again...</h3>
+    </div>
+  <% end %>
  
   <p>  
     <%= form.label("Title of Event") %><br>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4 @@
+{
+  "name": "community-calendar",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
falls jetzt ein event ohne titel kreiert wird, kommt eine error message. wenn allerdings keine start und end time angegeben wird, also start und end time identisch sind (sind sie ja per default), kommt eine error message, weil sie ja nicht "blank" bzw "null" sind. is vllt erstmal nich so wichtig, aber koennten naechste woche mal ueberlegen, wie man das loesen koennte. 
wenn das form-partial auch fuer edit genutzt wird, muesste die error message ja automatisch auch fuer den fall klappen, wenn man nen edit ohne titel createn will...